### PR TITLE
Add rule engine configuration option for changing the implementation of the jq function

### DIFF
--- a/apps/emqx_rule_engine/i18n/emqx_rule_engine_schema.conf
+++ b/apps/emqx_rule_engine/i18n/emqx_rule_engine_schema.conf
@@ -261,6 +261,17 @@ of the rule, then the string "undefined" is used.
       }
     }
 
+    rule_engine_jq_implementation_module {
+      desc {
+          en: "The implementation module for the jq rule engine function. The two options are jq_nif and jq_port. jq_nif uses an Erlang NIF library to access the jq library while jq_port uses an implementation based on Erlang port programs. The jq_nif option (the default option) is the fastest implementation of the two but jq_port is safer as the jq programs will not execute in the same process as the Erlang VM."
+          zh: ""
+      }
+      label: {
+          en: "Implementation module used by the rule engine jq function (jq_nif for NIF backend or jq_port for a port backend)"
+          zh: ""
+      }
+    }
+
     desc_rule_engine {
                    desc {
                          en: """Configuration for the EMQX Rule Engine."""

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -320,6 +320,10 @@ init([]) ->
         {write_concurrency, true},
         {read_concurrency, true}
     ]),
+    emqx_config_handler:add_handler(
+        [rule_engine, jq_implementation_module],
+        emqx_rule_engine_schema
+    ),
     {ok, #{}}.
 
 handle_call({insert_rule, Rule}, _From, State) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -25,7 +25,8 @@
     namespace/0,
     roots/0,
     fields/1,
-    desc/1
+    desc/1,
+    post_config_update/5
 ]).
 
 -export([validate_sql/1]).
@@ -48,6 +49,15 @@ fields("rule_engine") ->
                 #{
                     default => "10s",
                     desc => ?DESC("rule_engine_jq_function_default_timeout")
+                }
+            )},
+        {jq_implementation_module,
+            ?HOCON(
+                hoconsc:enum([jq_nif, jq_port]),
+                #{
+                    default => jq_nif,
+                    mapping => "jq.jq_implementation_module",
+                    desc => ?DESC("rule_engine_jq_implementation_module")
                 }
             )}
     ];
@@ -209,3 +219,13 @@ validate_sql(Sql) ->
         {ok, _Result} -> ok;
         {error, Reason} -> {error, Reason}
     end.
+
+post_config_update(
+    [rule_engine, jq_implementation_module],
+    _Req,
+    NewSysConf,
+    _OldSysConf,
+    _AppEnvs
+) ->
+    jq:set_implementation_module(NewSysConf),
+    ok.


### PR DESCRIPTION
This commit adds a rule engine configuration option for changing the implementation module used for the rule engine function jq. The two options are `jq_port` (uses Erlang port programs to interact with jq) and `jq_nif` (uses an Erlang NIF library to interact with jq).

**OBS** Things needed before merge

* Chinese translation for the description of the config option
* Bump the jq library version after [this PR]((https://github.com/emqx/jq/pull/36)) has been merged (the config option has no effect before that PR)