### PR TITLE
fix: do not start jq port programs when they are not needed

### DIFF
--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -398,7 +398,9 @@ relx_apps(ReleaseType, Edition) ->
         ] ++
         [quicer || is_quicer_supported()] ++
         [bcrypt || provide_bcrypt_release(ReleaseType)] ++
-        [jq || is_jq_supported()] ++
+        %% Started automatically when needed (only needs to be started when the
+        %% port implementation is used)
+        [{jq, load} || is_jq_supported()] ++
         [{observer, load} || is_app(observer)] ++
         relx_apps_per_edition(Edition).
 


### PR DESCRIPTION
The jq function in the rule engine uses the jq NIF implementation by default so there is often no need to start any jq port programs. Before this commit jq port programs were started anyway. This is fixed by not starting the jq application (the jq application is started automatically when the jq port implementation is activated).